### PR TITLE
fix: feed_api_key field doesn't show its "stored" state after masking

### DIFF
--- a/assets/js/config.js
+++ b/assets/js/config.js
@@ -6071,10 +6071,16 @@
         var input = document.getElementById('setFeedApiKey');
         var banner = document.getElementById('feedKeyMissingBanner');
         if (!input || !banner) return;
-        if (input.value.trim() === '') {
-            banner.classList.remove('d-none');
-        } else {
+        // feed_api_key is a data-secret field: a blank value on load doesn't
+        // mean "not configured", it means "stored, not shown". Trust the
+        // configured flag set by loadApiKeys() unless the admin has typed
+        // a new value this session.
+        var hasTypedValue = input.value.trim() !== '';
+        var isConfigured = input.dataset.configured === '1';
+        if (hasTypedValue || isConfigured) {
             banner.classList.add('d-none');
+        } else {
+            banner.classList.remove('d-none');
         }
     }
 
@@ -6082,6 +6088,19 @@
         apiGet('settings').then(function (data) {
             var settings = data.settings || {};
             applySettingsToForm(document.getElementById('apiKeysForm'), settings);
+            // feed_api_key is data-secret — the server never sends the real
+            // value, only a feed_api_key_set boolean. applySettingsToForm
+            // can't fill a field it wasn't given a value for, so handle the
+            // placeholder here (same "stored / not set" pattern as Slack's
+            // secret fields).
+            var feedInput = document.getElementById('setFeedApiKey');
+            if (feedInput) {
+                feedInput.value = '';
+                feedInput.dataset.configured = settings.feed_api_key_set ? '1' : '0';
+                feedInput.placeholder = settings.feed_api_key_set
+                    ? '•••• stored — leave blank to keep, type to replace'
+                    : '(empty — feed disabled)';
+            }
             updateFeedKeyBanner();
         }).catch(function (err) {
             showAlert('Failed to load API keys: ' + err.message, 'danger');


### PR DESCRIPTION
## Summary

Fixes the config.js half of #7. `07b9d1d` already fixed the actual data-loss bug (`data-secret="1"` on `feed_api_key` in `settings.php`) and covered the 9-field audit + boolean-masking issue — this PR doesn't touch any of that.

What's left is the piece explicitly called out as a separate gap in that thread: `applySettingsToForm()` has no concept of the `<name>_set` sentinel the server sends for masked fields, so a correctly-configured `feed_api_key` still renders as an empty box, and the "external feed is disabled" banner still shows even though a key is in fact set.

## Change

`loadApiKeys()` now reads `feed_api_key_set` and shows the same "stored — leave blank to keep, type to replace" placeholder `loadSlackConfig()` already uses for its own secret fields, tracking a `data-configured` flag so `updateFeedKeyBanner()` reflects the real state instead of just checking whether the box happens to be non-empty.

This branch previously also carried the `data-secret="1"` addition to `settings.php`, but that's now identical to what's already on `main` via `07b9d1d` — dropped it to keep this PR to just the one remaining gap, rather than duplicating your own fix.

## Testing

Verified end-to-end on a live install: with a key configured, the field now shows the "stored" placeholder and the banner stays hidden; saving an unrelated field on the same form no longer touches the key (confirmed via direct DB check) and the display now correctly reflects that.
