### PR TITLE
feat: Telegram channel adapter, test button, and setup guide

### DIFF
--- a/assets/js/config.js
+++ b/assets/js/config.js
@@ -3049,6 +3049,34 @@
                 showAlert('Telegram settings saved.');
             }).catch(function (err) { showAlert(err.message, 'danger'); });
         });
+
+        // The panel has shipped a "Send Test" button with nothing bound to it.
+        // Mirrors the #btnTestSlack handler below; api/chat.php's test_channel
+        // is admin-gated and CSRF-checked server-side.
+        var testBtn = document.getElementById('btnTestTelegram');
+        if (testBtn && !testBtn._bound) {
+            testBtn._bound = true;
+            testBtn.addEventListener('click', function () {
+                testBtn.disabled = true;
+                fetch('api/chat.php', {
+                    method: 'POST', credentials: 'same-origin',
+                    headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
+                    body: JSON.stringify({ action: 'test_channel', channel: 'telegram', body: 'Test message from TicketsCAD Telegram integration', csrf_token: csrfToken })
+                })
+                .then(function (r) { return r.json(); })
+                .then(function (data) {
+                    testBtn.disabled = false;
+                    if (data.error) { showAlert('Telegram test error: ' + data.error, 'danger'); return; }
+                    var result = data.result || null;
+                    if (result && result.success) {
+                        showAlert('Test message sent to Telegram.', 'success');
+                    } else {
+                        showAlert('Telegram failed: ' + ((result && result.error) || 'not configured'), 'danger');
+                    }
+                })
+                .catch(function (err) { testBtn.disabled = false; showAlert(err.message, 'danger'); });
+            });
+        }
     }
 
     // ── Slack Config ──

--- a/docs/MESSAGE-ROUTING-GUIDE.md
+++ b/docs/MESSAGE-ROUTING-GUIDE.md
@@ -29,6 +29,7 @@ A channel is a transport: a way messages get delivered. TicketsCAD has 10+ regis
 | `local_chat` | both | In-app chat broker, always on |
 | `push` | outbound | Web push notifications to browser/mobile (per-user) |
 | `slack` | outbound | Slack workspace via incoming webhook or bot token |
+| `telegram` | outbound | Telegram group via a bot ([setup guide](TELEGRAM-SETUP-GUIDE.md)) |
 | `sms` | outbound | Generic REST / Twilio / BulkVS / Pushbullet |
 | `smtp` | outbound | Email via SMTP |
 | `email` | outbound | Alias for smtp |

--- a/docs/ROUTING-ENGINE-REFERENCE.md
+++ b/docs/ROUTING-ENGINE-REFERENCE.md
@@ -233,6 +233,7 @@ The `dest_channel` of a route must correspond to a [broker](GLOSSARY.md#broker) 
 | `email` | [`inc/channels/email.php`](../inc/channels/email.php) | Alias for `smtp` |
 | `sms` | [`inc/channels/sms.php`](../inc/channels/sms.php) | Production (Twilio / BulkVS / Pushbullet) |
 | `slack` | [`inc/channels/slack.php`](../inc/channels/slack.php) | Production (Slack incoming webhook) |
+| `telegram` | [`inc/channels/telegram.php`](../inc/channels/telegram.php) | Production (Bot API `sendMessage`; outbound only) |
 | `meshtastic` | [`inc/channels/meshtastic.php`](../inc/channels/meshtastic.php) | Production (mesh bridge VM running) |
 | `dmr` | [`inc/channels/dmr.php`](../inc/channels/dmr.php) | Stub — basic shape, real implementation via DVSwitch bridge |
 | `zello` | `inc/channel_registry.php` (stub) | Stub — registered, awaiting Zello Work API impl |

--- a/docs/TELEGRAM-SETUP-GUIDE.md
+++ b/docs/TELEGRAM-SETUP-GUIDE.md
@@ -1,0 +1,243 @@
+# Telegram Setup Guide — TicketsCAD
+
+**Audience:** Administrators wiring up the Telegram channel for the first time.
+**Version:** NewUI v4.0. Reflects the Telegram integration as shipped
+(outbound text only — incident, PAR and system alerts posted to a Telegram
+group as a bot).
+
+Telegram is one of the simplest channels to set up — two values pasted into
+Settings — but two of the steps fail in ways that point you at the wrong
+problem. Both are called out below where they bite.
+
+---
+
+## Table of contents
+
+1. [What Telegram adds, and when to use it](#1-what-telegram-adds-and-when-to-use-it)
+2. [Create the bot with BotFather](#2-create-the-bot-with-botfather)
+3. [Create the group and add the bot](#3-create-the-group-and-add-the-bot)
+4. [Find the chat ID (the gotcha)](#4-find-the-chat-id-the-gotcha)
+5. [Configure TicketsCAD](#5-configure-ticketscad)
+6. [Route messages to Telegram](#6-route-messages-to-telegram)
+7. [Troubleshooting](#7-troubleshooting)
+8. [Quick reference](#8-quick-reference)
+
+---
+
+## 1. What Telegram adds, and when to use it
+
+Telegram lets TicketsCAD post text into a group chat that your people already
+have on their phones. It is **outbound only** — TicketsCAD posts to the group
+and does not read replies, so it suits announcements rather than conversation:
+
+- Incident alerts to an on-call or duty group.
+- PAR and system notifications.
+- Anything you would otherwise send by group SMS, without per-message cost.
+
+**When to reach for something else.** If you need two-way traffic, voice, or
+per-unit direct messages, Zello is the channel for that
+([`ZELLO-SETUP-GUIDE.md`](ZELLO-SETUP-GUIDE.md)). Telegram is the low-effort
+option for one-way notification to a group of people with smartphones.
+
+There is no server-side daemon to run: sends go out over HTTPS from the web
+process, so nothing needs installing beyond the two settings below.
+
+---
+
+## 2. Create the bot with BotFather
+
+1. In Telegram, search for **@BotFather** (the one with the blue verified
+   check) and start a chat.
+2. Send `/newbot`.
+3. Give it a display name (anything — e.g. `Dispatch Alerts`).
+4. Give it a username ending in `bot` — e.g. `YourOrgCADbot`. It must be
+   globally unique, so expect a couple of tries.
+5. BotFather replies with a token that looks like:
+
+   ```
+   123456789:AAHt-abcdefGHIJKLmnopQRSTuvwx-yz12345
+   ```
+
+   Copy it. You will paste it into Settings in step 5.
+
+> **Treat the token like a password.** Anyone holding it can post as your bot.
+> If it leaks, send `/revoke` to BotFather and paste the new one into Settings.
+
+---
+
+## 3. Create the group and add the bot
+
+1. Create a Telegram group (or use an existing one) containing the people who
+   should receive alerts.
+2. **Add your bot to the group** as a member — search for the `…bot` username
+   you chose in step 2.
+3. If the group is a channel-style broadcast group, give the bot **Admin**
+   rights so it is permitted to post.
+
+> **Do not skip this before step 4.** Until the bot is actually a member of the
+> group, the group will not appear in the lookup below at all — which reads as
+> "the lookup is broken" rather than "the bot isn't in the group yet".
+
+---
+
+## 4. Find the chat ID (the gotcha)
+
+1. Send any message **in the group** — not a direct message to the bot. Just
+   "test" is fine.
+2. In a browser, open (replacing `<TOKEN>` with the token from step 2):
+
+   ```
+   https://api.telegram.org/bot<TOKEN>/getUpdates
+   ```
+
+3. Look through the JSON for a `chat` object and take its `id`:
+
+   ```json
+   "chat": { "id": -1001234567890, "title": "Dispatch Alerts", "type": "supergroup" }
+   ```
+
+### This is where people get stuck
+
+**The group's chat ID is negative.** Group and supergroup IDs start with `-`,
+usually `-100…`. Copy the minus sign along with the digits.
+
+`getUpdates` will happily also show you the chat ID of your **private** chat
+with the bot — a *positive* number — if you messaged the bot directly at any
+point. Using that positive ID looks correct and fails with:
+
+```
+Forbidden: bot can't initiate conversation with a user
+```
+
+which reads like a permissions problem with the bot and is actually the wrong
+chat ID. If you see that error, you almost certainly have a DM id where you
+want the group's.
+
+Check the `"type"` field to be sure: you want `"group"` or `"supergroup"`, not
+`"private"`.
+
+> If `getUpdates` returns an empty `result` array, the bot is not in the group
+> (step 3), or no message has been sent in the group since it joined (step 4.1).
+
+---
+
+## 5. Configure TicketsCAD
+
+Go to **Settings → Telegram Bot** and fill in the two fields:
+
+| Field | Value |
+|---|---|
+| **Bot Token** | The `123456789:AA…` token from step 2 |
+| **Chat ID** | The **negative** group ID from step 4, e.g. `-1001234567890` |
+
+Click **Save**, then **Send Test**. A confirmation message should arrive in the
+group within a second or two.
+
+Both values are format-checked on save, so a mistyped or half-pasted token is
+reported as malformed rather than failing later with an opaque error from
+Telegram.
+
+---
+
+## 6. Route messages to Telegram
+
+Configuring the channel does not by itself send anything. Traffic reaches
+Telegram through the routing engine, the same as any other channel:
+
+**Settings → Communications → Message Routing** → add a route with
+`dest_channel = telegram`.
+
+See [`MESSAGE-ROUTING-GUIDE.md`](MESSAGE-ROUTING-GUIDE.md) for filters and
+transforms, and [`ROUTING-ENGINE-REFERENCE.md`](ROUTING-ENGINE-REFERENCE.md)
+for the full route schema.
+
+The destination chat is taken from the **Chat ID** setting for every message —
+it is deliberately not settable per message or per route. One bot credential
+posts to one configured group.
+
+---
+
+## 7. Troubleshooting
+
+### `Forbidden: bot can't initiate conversation with a user`
+
+The chat ID is a private/DM id (positive) rather than the group's (negative).
+Redo [step 4](#4-find-the-chat-id-the-gotcha) and check the `"type"` field is
+`group` or `supergroup`.
+
+### `Bad Request: chat not found`
+
+The chat ID is wrong, or the bot has been removed from the group. Confirm the
+bot is still a member, send a fresh message in the group, and re-check
+`getUpdates`.
+
+### `getUpdates` shows an empty `result`
+
+The bot is not in the group, or nothing has been said in the group since it
+joined. Both are [step 3](#3-create-the-group-and-add-the-bot).
+
+### "Telegram bot token is malformed"
+
+The token does not look like `<digits>:<secret>` — usually a partial paste, a
+stray space, or the bot *username* pasted instead of the token. Re-copy it from
+BotFather, or `/revoke` and use the replacement.
+
+### "Telegram chat ID is malformed"
+
+The chat ID is not an integer — usually the group *title* or an `@username`
+pasted instead of the numeric id, or the minus sign dropped.
+
+### "Telegram not configured"
+
+One of the two fields is empty. Note that the Bot Token field intentionally
+shows as blank once saved (it is stored as a secret); leave it blank to keep
+the existing token, or type a new one to replace it.
+
+### Nothing arrives, but Send Test reports success
+
+The bot posted to a different group than you are watching — a stale chat ID
+from an earlier group. Re-run [step 4](#4-find-the-chat-id-the-gotcha) against
+the group you actually want.
+
+### The bot was working and stopped
+
+Check whether the bot is still a member of the group, and whether the token was
+revoked. Telegram silently drops a bot from a group when it is removed by an
+admin; sends then fail with `chat not found`.
+
+---
+
+## 8. Quick reference
+
+**Outside TicketsCAD (Telegram side):**
+
+| What | Where | Notes |
+|---|---|---|
+| Create the bot | **@BotFather** → `/newbot` | Username must end in `bot` |
+| Bot token | BotFather's reply | `123456789:AA…` — treat as a password |
+| Add bot to group | Telegram group → add member | Required before the chat ID lookup works |
+| Chat ID | `https://api.telegram.org/bot<TOKEN>/getUpdates` | **Negative** number, `type` = `group`/`supergroup` |
+| Revoke a leaked token | **@BotFather** → `/revoke` | Then paste the new one into Settings |
+
+**Inside TicketsCAD:**
+
+| Field (Settings → Telegram Bot) | Value |
+|---|---|
+| Bot Token | `123456789:AA…` from BotFather |
+| Chat ID | Negative group ID, e.g. `-1001234567890` |
+| Send Test | Posts a confirmation message to the group |
+
+**Where the pieces live:**
+
+| Piece | Location |
+|---|---|
+| Channel adapter | [`inc/channels/telegram.php`](../inc/channels/telegram.php) |
+| Settings panel | Settings → Telegram Bot |
+| Routing | Settings → Communications → Message Routing, `dest_channel = telegram` |
+
+---
+
+*The single most common failure is a positive (DM) chat ID where the group's
+negative one belongs — it fails with a message about bot permissions that gives
+no hint the ID is wrong. Re-check [step 4](#4-find-the-chat-id-the-gotcha)
+first.*

--- a/inc/channels/telegram.php
+++ b/inc/channels/telegram.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Channel: Telegram
+ *
+ * Posts incident / PAR / system alerts to a Telegram chat via a bot,
+ * using the Telegram Bot API (sendMessage). Outbound only.
+ *
+ * Configuration (Settings → Telegram):
+ *   telegram_bot_token = Bot token from @BotFather
+ *   telegram_chat_id   = Target group chat ID (negative, e.g. -100123456789)
+ *
+ * Setup: docs/TELEGRAM-SETUP-GUIDE.md
+ */
+
+broker_register('telegram', [
+    'name'    => 'Telegram',
+    'send'    => '_telegram_send',
+    'receive' => '_telegram_receive',
+    'status'  => '_telegram_status'
+]);
+
+/**
+ * Telegram bot tokens are `<numeric bot id>:<35-ish char secret>`. Chat ids
+ * are integers, negative for groups and supergroups. Validating both lets a
+ * mistyped or whitespace-padded value fail with something an admin can act
+ * on, rather than an opaque 404 from Telegram.
+ */
+define('TELEGRAM_TOKEN_RE',   '/^\d+:[A-Za-z0-9_-]{20,}$/');
+define('TELEGRAM_CHAT_ID_RE', '/^-?\d{1,20}$/');
+
+function _telegram_send(array $message) {
+    $config = _telegram_get_config();
+    $token  = trim((string) ($config['telegram_bot_token'] ?? ''));
+
+    // The destination is bound to the bot credential and comes from
+    // configuration ONLY — deliberately not overridable per message.
+    //
+    // inc/router.php forwards a matched message array wholesale to the
+    // destination adapter (_router_transform() rewrites body/priority/type
+    // and leaves every other key intact), and two receive handlers return
+    // raw third-party JSON into that path — _slack_receive() returns
+    // $data['messages'], _sms_receive() returns $data['threads']. Neither
+    // provider currently lets a message author set an arbitrary top-level
+    // key, so an override here is unreachable today; but that is a property
+    // of someone else's response schema, not of this codebase, and nothing
+    // tells us when it changes. Reading the chat id from config removes the
+    // question entirely.
+    //
+    // A per-message destination may be worth having later (routing weather
+    // to one chat and dispatch to another), but it needs an admin-configured
+    // allowlist plus the router's _is_routed_forward trust marker — not an
+    // unchecked key. See openises/TicketsCAD#10 review.
+    $chatId = trim((string) ($config['telegram_chat_id'] ?? ''));
+
+    if ($token === '' || $chatId === '') {
+        return ['success' => false, 'error' => 'Telegram not configured'];
+    }
+    if (!preg_match(TELEGRAM_TOKEN_RE, $token)) {
+        return ['success' => false, 'error' => 'Telegram bot token is malformed (expected "123456:ABC-DEF..." from @BotFather)'];
+    }
+    if (!preg_match(TELEGRAM_CHAT_ID_RE, $chatId)) {
+        return ['success' => false, 'error' => 'Telegram chat ID is malformed (expected an integer; group IDs are negative, e.g. -100123456789)'];
+    }
+
+    $body = $message['body'] ?? '';
+    if (!$body) {
+        return ['success' => false, 'error' => 'Message body required'];
+    }
+
+    $payload = json_encode([
+        'chat_id' => $chatId,
+        'text'    => $body,
+    ]);
+
+    $ch = curl_init('https://api.telegram.org/bot' . $token . '/sendMessage');
+    // Stated explicitly rather than relying on defaults: the defaults are
+    // safe, but a host with unusual curl.* ini settings changes that, and a
+    // reader cannot otherwise tell "safe by default" from "nobody checked".
+    // Matches inc/webhooks.php and api/dmr-lookup.php.
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER  => true,
+        CURLOPT_POST            => true,
+        CURLOPT_POSTFIELDS      => $payload,
+        CURLOPT_HTTPHEADER      => ['Content-Type: application/json'],
+        CURLOPT_SSL_VERIFYPEER  => true,
+        CURLOPT_SSL_VERIFYHOST  => 2,
+        CURLOPT_FOLLOWLOCATION  => false,
+        CURLOPT_PROTOCOLS       => CURLPROTO_HTTPS,
+        CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTPS,
+        CURLOPT_CONNECTTIMEOUT  => 5,
+        // Sends are synchronous inside broker_send(), so a route fanning out
+        // to Telegram adds up to this many seconds to the request that
+        // triggered it.
+        CURLOPT_TIMEOUT         => 10,
+    ]);
+
+    $resp = curl_exec($ch);
+    $err  = curl_error($ch);
+    curl_close($ch);
+
+    if ($resp === false) {
+        return ['success' => false, 'error' => 'Telegram request failed: ' . $err];
+    }
+
+    $data = json_decode($resp, true);
+    if (!empty($data['ok'])) {
+        return ['success' => true, 'message_id' => $data['result']['message_id'] ?? null];
+    }
+    // Surface Telegram's own `description` when it sends one — those are
+    // actionable ("chat not found", "bot was blocked by the user"). When it
+    // doesn't, return a fixed string rather than echoing the raw body into
+    // the admin UI; log the body instead so it's still diagnosable. The
+    // token lives in the URL, not the body, so it is not logged here.
+    if (isset($data['description'])) {
+        return ['success' => false, 'error' => 'Telegram API: ' . $data['description']];
+    }
+    error_log('[telegram] unexpected sendMessage response: ' . substr((string) $resp, 0, 500));
+    return ['success' => false, 'error' => 'Telegram API returned an unexpected response (see error log)'];
+}
+
+/** No inbound polling — TicketsCAD only posts to Telegram, it doesn't read replies. */
+function _telegram_receive($limit = 50) {
+    return [];
+}
+
+function _telegram_get_config() {
+    $prefix = $GLOBALS['db_prefix'] ?? '';
+    $keys = ['telegram_bot_token', 'telegram_chat_id'];
+    $config = [];
+    foreach ($keys as $k) {
+        try {
+            $val = db_fetch_value("SELECT `value` FROM `{$prefix}settings` WHERE `name` = ?", [$k]);
+            $config[$k] = $val;
+        } catch (Exception $e) {
+            // Treat as unconfigured (_telegram_send then reports "not
+            // configured"), but don't swallow the reason — a settings-table
+            // failure here is otherwise indistinguishable from a blank field.
+            $config[$k] = null;
+            error_log("[telegram] could not read setting '{$k}': " . $e->getMessage());
+        }
+    }
+    return $config;
+}
+
+function _telegram_status() {
+    $config = _telegram_get_config();
+    $token  = trim((string) ($config['telegram_bot_token'] ?? ''));
+    $chatId = trim((string) ($config['telegram_chat_id'] ?? ''));
+    if ($token === '' || $chatId === '') return 'not_configured';
+    // Report malformed credentials as not-configured rather than configured:
+    // a status of "configured" that cannot send is worse than an honest one.
+    if (!preg_match(TELEGRAM_TOKEN_RE, $token))     return 'not_configured';
+    if (!preg_match(TELEGRAM_CHAT_ID_RE, $chatId))  return 'not_configured';
+    return 'configured';
+}


### PR DESCRIPTION
## Summary

Adds the Telegram channel adapter — the backend behind a Settings panel that has been shipping a complete configuration UI, including a "Send Test" button, with nothing behind it.

**Scope reduced per @ejosterberg's review.** The `proc_open` conversion, the `wmic` → `Get-CimInstance` fallback, the MySQL 8.0 `TEXT DEFAULT` fix and the `telegram_bot_token` blanking are all in the dev tree already (`8a9ec2a` and others), so this branch is now only the part with nothing behind it, rebased onto current `main`. Eleven files became five.

## What was broken

- No `inc/channels/telegram.php`, so `broker_send('telegram', …)` was rejected as an unregistered channel — silently, for routed incident/PAR/system alerts.
- Nothing bound to `#btnTestTelegram`, so the shipped "Send Test" button did nothing at all.

## Changes

- **`inc/channels/telegram.php`** — Bot API `sendMessage` over cURL, registered via `broker_register()` and picked up by `inc/broker.php`'s glob.
- **`assets/js/config.js`** — the missing `#btnTestTelegram` handler, mirroring `#btnTestSlack`. Deliberately does **not** touch `loadTelegramConfig()`'s save path: the `data-secret` blanking is fixed generally in the dev tree and changing it here would collide.
- **`docs/TELEGRAM-SETUP-GUIDE.md`** — modelled on `ZELLO-SETUP-GUIDE.md`.
- **Channel-table rows** in `MESSAGE-ROUTING-GUIDE.md` and `ROUTING-ENGINE-REFERENCE.md`.

## The four review items

**1 — Destination pinned to configuration.** The `$message['telegram_chat_id']` override is gone; the chat id is read from config only.

Verified rather than asserted: with an **invalid** configured chat id and a **valid** override supplied, the send fails closed on validation and transmits nothing. If the override were still honoured it would have proceeded.

```
with invalid config + valid override:
  {"success":false,"error":"Telegram chat ID is malformed (…)"}
  => PINNED — override ignored, failed closed, nothing sent
```

The reasoning is recorded in a comment at the call site, including why it was unreachable (no provider currently permits an arbitrary top-level key) and why that is not a guarantee this codebase owns.

**2 — cURL options stated explicitly.** `VERIFYPEER`, `VERIFYHOST 2`, no redirects, HTTPS-only for both protocols and redirects, `CONNECTTIMEOUT 5`. Matches `inc/webhooks.php` and `api/dmr-lookup.php`. Existing `TIMEOUT 10` kept, with the synchronous-inside-`broker_send()` consequence noted in a comment.

**3 — Format validation, failing closed.** Token against `/^\d+:[A-Za-z0-9_-]{20,}$/`, chat id against `/^-?\d{1,20}$/`, both with actionable messages instead of an opaque Telegram 404. `_telegram_status()` applies the same checks, so malformed credentials report `not_configured` rather than a "configured" state that cannot send.

**4 — Setup guide.** Records both non-guessable facts: the chat id must be the group's **negative** id (a positive DM id fails with `Forbidden: bot can't initiate conversation with a user`, which reads as a permissions problem rather than a wrong id), and the bot must already be a member of the group before `getUpdates` shows the chat.

## Testing

Verified against a live bot and group on Windows/IIS, PHP 8.4.22, MySQL 8.0:

- Adapter registers through the broker glob; `_telegram_status()` reports `configured`.
- **Send Test** delivers to the group.
- Malformed token and malformed chat id are both rejected before any request is made.
- The pinning test above.
