### PR TITLE
Fix EOC unit update age for live GPS tracking

### DIFF
--- a/situation.php
+++ b/situation.php
@@ -1209,6 +1209,27 @@ $sitResetOffscreen = ($sitResetOffscreenRaw === false || $sitResetOffscreenRaw =
         return Math.floor(s / 86400) + 'd ago';
     }
 
+    // A GPS fix is a unit update too. Keep the EOC Units table aligned with
+    // the map by showing the newest of the tracking, status, and unit-row
+    // timestamps instead of reporting an old status change while fresh
+    // Traccar/OwnTracks positions continue to arrive.
+    function sitLatestAgo() {
+        var latest = '';
+        var latestMs = -Infinity;
+        var fallback = '';
+        for (var i = 0; i < arguments.length; i++) {
+            var value = arguments[i];
+            if (!value) continue;
+            if (!fallback) fallback = value;
+            var parsed = new Date(String(value).replace(' ', 'T')).getTime();
+            if (!isNaN(parsed) && parsed > latestMs) {
+                latest = value;
+                latestMs = parsed;
+            }
+        }
+        return sitAgo(latest || fallback);
+    }
+
     // GH #49 (round 3) — respect the CONFIGURED facility-status colors, exactly
     // like the (correct) Facilities page does (facilities.js: uses f.bg_color /
     // f.text_color / f.status_name straight from api/facilities.php). The old
@@ -1483,7 +1504,7 @@ $sitResetOffscreen = ($sitResetOffscreenRaw === false || $sitResetOffscreenRaw =
                     + (u.status_text_color ? 'color:' + esc(u.status_text_color) + ';' : '')
                     + 'font-size:0.62rem;">' + esc(u.status_name || '') + '</span></td>' +
                 '<td>' + esc(addr) + '</td>' +
-                '<td class="text-body-secondary" style="font-size:0.68rem;">' + sitAgo(u.status_updated || u.updated) + '</td>' +
+                '<td class="text-body-secondary" style="font-size:0.68rem;">' + sitLatestAgo(u.last_track, u.status_updated, u.updated) + '</td>' +
                 '</tr>';
         }
         tbody.innerHTML = html;

--- a/tests/test_situation_map_fixes.php
+++ b/tests/test_situation_map_fixes.php
@@ -87,6 +87,13 @@ t("situation refresh intervals are configurable (get_setting), not hard-coded",
     strpos($s, 'refreshInterval: <?php echo (int) ($sitUnitRefreshSecs') !== false &&
     strpos($s, '}, <?php echo (int) ($sitBoardRefreshSecs') !== false);
 
+// GH #71 — GPS ingest can advance while the unit status remains unchanged.
+// The EOC Updated cell must include the resolved last_track timestamp and
+// compare it with status/unit timestamps instead of using a stale first value.
+t("GH#71: EOC unit Updated cell uses the newest GPS/status/unit timestamp",
+    strpos($s, 'function sitLatestAgo()') !== false &&
+    strpos($s, 'sitLatestAgo(u.last_track, u.status_updated, u.updated)') !== false);
+
 // ── #60/#46 — situation control gets the shared per-category markup overlays ──
 t("#60: situation.php attaches MapPrefs.addMarkupOverlays (dashboard-parity layer toggles)",
     (bool) preg_match('/MapPrefs\.addMarkupOverlays\(map, sitLayersControl\)/', $s) &&


### PR DESCRIPTION
Fixes #71.

The responder API already exposes `last_track` from the resolved tracking provider's `received_at`, and the EOC map consumes the resulting coordinates. The Units table's **Updated** cell only considered `status_updated || updated`, so a unit receiving fresh Traccar positions could still display the age of an old status change.

This change:

- includes `last_track` in the EOC activity timestamp;
- selects the newest parseable tracking, status, or unit-row timestamp rather than the first truthy value;
- preserves the first nonblank value as a fallback for an unexpected timestamp format;
- adds a focused regression guard.

Verification:

- `php -l situation.php`
- `php tests/test_situation_map_fixes.php` — 35 passed, 0 failed
- `git diff --check`

No backend ingest or coordinate-selection behavior changes.
