### PR TITLE
fix(situation): make live-GPS unit overlay toggleable in the layer control

### DIFF
--- a/situation.php
+++ b/situation.php
@@ -165,6 +165,13 @@ $sitResetOffscreen = ($sitResetOffscreenRaw === false || $sitResetOffscreenRaw =
         }
         .sit-zone-label::before { display: none; }
 
+        /* GH #74 -- live-GPS layer-control legend dot. A CSS class rather
+           than an inline style="" so the colour can be overridden by a
+           stylesheet (the project's UI-consistency audit flags inline hex
+           colours specifically because no stylesheet can win against them
+           without !important; a class does not have that problem). */
+        .sit-legend-live-gps { color: #fd7e14; }
+
         /* Collapse toggle icon */
         .sit-toggle { cursor: pointer; user-select: none; }
         .sit-toggle .bi { transition: transform 0.2s; }
@@ -2065,7 +2072,7 @@ $sitResetOffscreen = ($sitResetOffscreenRaw === false || $sitResetOffscreenRaw =
                 var liveGpsLayer = tracker.getLayerGroup();
                 if (liveGpsLayer) {
                     sitLayersControl.addOverlay(liveGpsLayer,
-                        '<span style="color:#fd7e14">&#9679;</span> Units — live GPS');
+                        '<span class="sit-legend-live-gps">&#9679;</span> Units — live GPS');
                     if (window.MapLayerPrefs && window.MapLayerPrefs.register) {
                         window.MapLayerPrefs.register(map, 'units_live', liveGpsLayer);
                     }

--- a/situation.php
+++ b/situation.php
@@ -2049,6 +2049,28 @@ $sitResetOffscreen = ($sitResetOffscreenRaw === false || $sitResetOffscreenRaw =
                 }
             });
             tracker.start();
+
+            // GH #71 follow-up (cbyrdmo, 2026-08-17) — the live-GPS tracking
+            // overlay was added straight to the map (UnitTracking.init does
+            // L.layerGroup().addTo(map)) and never registered in the layer
+            // control. The "Units (EOC)" checkbox only governs the status-
+            // coloured EOC roster layer (unitMarkers), so switching units off
+            // left the live-GPS markers on screen — drawn in each unit's
+            // configured tracking colour (e.g. orange) rather than the green
+            // status colour — and operators read that as "units won't turn
+            // off." Register the tracking group as its own toggleable overlay
+            // (default on, unchanged) so it can be hidden, and persist that
+            // choice per-user like the other overlays.
+            if (sitLayersControl && typeof tracker.getLayerGroup === 'function') {
+                var liveGpsLayer = tracker.getLayerGroup();
+                if (liveGpsLayer) {
+                    sitLayersControl.addOverlay(liveGpsLayer,
+                        '<span style="color:#fd7e14">&#9679;</span> Units — live GPS');
+                    if (window.MapLayerPrefs && window.MapLayerPrefs.register) {
+                        window.MapLayerPrefs.register(map, 'units_live', liveGpsLayer);
+                    }
+                }
+            }
         }
 
         // Fallback polling every 15s for incidents (SSE handles real-time when available)

--- a/tests/test_gh71_live_gps_layer_toggle.php
+++ b/tests/test_gh71_live_gps_layer_toggle.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * GH #71 follow-up — live-GPS tracking overlay must be toggleable
+ * (cbyrdmo, 2026-08-17, from a live volunteer fire/EMS EOC deployment).
+ *
+ * Reported behavior: "If I disable units on the [layers] menu, the units
+ * still appear on the map. They are now orange instead of green." The popup
+ * on those markers reads "Unit — Last fix: Ns ago".
+ *
+ * Root cause: situation.php draws units through TWO independent layers.
+ *
+ *   1. unitMarkers  — the EOC roster layer, coloured by status
+ *      (Available/On Shift = green #198754, On Scene = orange, ...). This is
+ *      the one registered in the layer control as the "Units (EOC)" checkbox.
+ *
+ *   2. UnitTracking  — the real-time GPS overlay (assets/js/unit-tracking.js).
+ *      UnitTracking.init() does `L.layerGroup().addTo(map)` and hands the
+ *      group back via getLayerGroup(), but situation.php never registered it
+ *      in the layer control. Its markers are coloured by each unit's tracking
+ *      colour (unit.color, e.g. orange) and carry the "— Last fix:" tooltip.
+ *
+ * Because only layer #1 was behind the "Units (EOC)" checkbox, switching units
+ * off removed the green roster markers and left the orange live-GPS markers on
+ * screen with no control to hide them — exactly what the operator saw.
+ *
+ * Fix: register the tracking group as its own toggleable overlay (default on,
+ * so nothing changes for installs that leave it alone) and register it with
+ * MapLayerPrefs so the choice persists per user like every other overlay.
+ *
+ * Static guards over situation.php's inline JS (behavioral JS in a PHP file;
+ * no headless DOM here, matching tests/test_situation_map_fixes.php).
+ * Usage: php tests/test_gh71_live_gps_layer_toggle.php
+ */
+
+$base = realpath(__DIR__ . '/..');
+$passed = 0; $failed = 0;
+function t($label, $cond) { global $passed, $failed; echo ($cond ? "[PASS] " : "[FAIL] ") . $label . "\n"; $cond ? $passed++ : $failed++; }
+
+echo "=== GH #71 follow-up (live-GPS overlay toggle) ===\n\n";
+
+$s = @file_get_contents($base . '/situation.php');
+if ($s === false) { t('situation.php readable', false); echo "\n=== $passed passed, $failed failed ===\n"; exit(1); }
+
+// ── the tracking group is added to the layer control so it can be hidden ──
+// It must be sourced from the tracker itself (getLayerGroup), not a fresh
+// throwaway group, or the checkbox would toggle nothing.
+t("#71: the live-GPS tracker layer is registered in sitLayersControl via getLayerGroup()",
+    (bool) preg_match('/tracker\.getLayerGroup\(\)/', $s)
+        && (bool) preg_match('/sitLayersControl\.addOverlay\(\s*liveGpsLayer/', $s));
+
+t("#71: the new overlay carries a distinct 'Units — live GPS' label (not confusable with 'Units (EOC)')",
+    strpos($s, 'Units — live GPS') !== false);
+
+// ── the wiring is guarded so a build without the control/tracker is a no-op ──
+t("#71: registration is guarded on sitLayersControl AND tracker.getLayerGroup existing",
+    (bool) preg_match('/if\s*\(\s*sitLayersControl\s*&&\s*typeof\s+tracker\.getLayerGroup\s*===\s*[\'"]function[\'"]\s*\)/', $s));
+
+// ── per-user persistence parity with the other overlays ──
+t("#71: the live-GPS overlay is registered with MapLayerPrefs so its state persists per user",
+    (bool) preg_match('/MapLayerPrefs\.register\(\s*map\s*,\s*[\'"]units_live[\'"]\s*,\s*liveGpsLayer\s*\)/', $s));
+
+// ── regression: the existing EOC layer wiring is untouched ──
+t("#71 regression: unitMarkers is still registered as the 'Units (EOC)' overlay",
+    (bool) preg_match('/sitLayersControl\.addOverlay\(\s*unitMarkers/', $s)
+        && strpos($s, 'Units (EOC)') !== false);
+
+t("#71 regression: UnitTracking overlay is still added to the map (default-on unchanged)",
+    (bool) preg_match('/UnitTracking\.init\(map/', $s)
+        && (bool) preg_match('/tracker\.start\(\)/', $s));
+
+echo "\n=== $passed passed, $failed failed ===\n";
+exit($failed === 0 ? 0 : 1);


### PR DESCRIPTION
Fixes #74.

### Problem

On `situation.php` the EOC map draws units through two independent layers:

1. **`unitMarkers`** — the status-coloured roster layer, already registered in the Leaflet layer control as the **Units (EOC)** checkbox.
2. **`UnitTracking`** (`assets/js/unit-tracking.js`) — the real-time GPS overlay. `UnitTracking.init()` does `L.layerGroup().addTo(map)` and exposes the group via `getLayerGroup()`, but `situation.php` **never registered it in the layer control**.

So unchecking **Units (EOC)** hid only the green roster markers; the live-GPS markers (coloured orange by `unit.color`, with the `"— Last fix:"` tooltip) stayed on screen with no way to hide them. Reported by @cbyrdmo on a live volunteer fire/EMS EOC deployment (#71 follow-up).

### Fix

Register the tracking layer group as its own toggleable overlay — **"Units — live GPS"** — and register it with `MapLayerPrefs` so the choice persists per user, matching the other overlays. The layer stays **on by default** (Leaflet checks the overlay box when the layer is already on the map), so nothing changes for existing installs unless an operator toggles it. Uses the exact `addOverlay` + `MapLayerPrefs.register` patterns already used 4× in this file.

```
if (sitLayersControl && typeof tracker.getLayerGroup === 'function') {
    var liveGpsLayer = tracker.getLayerGroup();
    if (liveGpsLayer) {
        sitLayersControl.addOverlay(liveGpsLayer, '… Units — live GPS');
        if (window.MapLayerPrefs && window.MapLayerPrefs.register) {
            window.MapLayerPrefs.register(map, 'units_live', liveGpsLayer);
        }
    }
}
```

### Testing

- New `tests/test_gh71_live_gps_layer_toggle.php` (static source guards, matching `tests/test_situation_map_fixes.php`): **6/6 pass**.
- Existing `tests/test_situation_map_fixes.php`: **34/34 pass** (no regression).
- `php -l situation.php`: clean.
- Independent adversarial review (external model): ACCEPT — no default-visibility regression, no null/throw path (both `sitLayersControl` and the layer are guarded, `MapLayerPrefs.register` is defensive), static label = no XSS, narrowly scoped.

Note: `situation.php`'s map behavior is JS embedded in PHP; per the repo's convention these are static guards, not a headless-DOM test. I did not have a browser to visually confirm the live toggle.

### Design choice (maintainer input welcome)

This keeps the two unit layers as **two** checkboxes (roster vs. live GPS), which is the smallest safe change and lets an operator view either independently. If you'd prefer the single **Units (EOC)** checkbox to govern **both** layers (one toggle hides all unit markers), I'm glad to revise — that variant changes live-map behavior and would want a browser check before merge.
